### PR TITLE
:rubygems source is insecure - use https://rubygems.org instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem "nokogiri"
 


### PR DESCRIPTION
The source :rubygems is insecure. As recommended by the warning
message when this source is used, update the source to be
https://rubygems.org.
