### PR TITLE
Enable the RemoteIpValve in the default Tomcat configuration

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -31,7 +31,10 @@
                connectionTimeout="20000" bindOnInit="false"/>
 
     <Engine name="Catalina" defaultHost="localhost">
-
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+             proxiesHeader="x-forwarded-for"
+             protocolHeader="x-forwarded-proto"
+             portHeader="x-forwarded-port" />
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
       </Host>


### PR DESCRIPTION
It would be nice to have the RemoteIpValve enabled by default, since the Tomcat instance created by the build pack is behind a proxy.  This is not as important with HTTP traffic, but it's important with HTTPS traffic, as without the valve the "HttpServletRequest.isSecure()" method will incorrectly return false.
